### PR TITLE
Fix log entries when the mode is undefined or unexpected

### DIFF
--- a/src/main/java/fr/jmini/asciidoctorj/gitlink/GitLinkMacro.java
+++ b/src/main/java/fr/jmini/asciidoctorj/gitlink/GitLinkMacro.java
@@ -40,8 +40,11 @@ public class GitLinkMacro extends InlineMacroProcessor {
 
     GitLink link = GitLinkUtility.compute(path, mode, server, repository, branch, linkText, docFile);
 
-    if (link.getWarning() != null) {
-      log(new LogRecord(Severity.WARN, link.getWarning()));
+    if (link.getWarningLogMessage() != null) {
+      log(new LogRecord(Severity.WARN, link.getWarningLogMessage()));
+    }
+    if (link.getDebugLogMessage() != null) {
+      log(new LogRecord(Severity.DEBUG, link.getDebugLogMessage()));
     }
 
     if (link.getUrl() == null) {

--- a/src/main/java/fr/jmini/asciidoctorj/gitlink/internal/GitLink.java
+++ b/src/main/java/fr/jmini/asciidoctorj/gitlink/internal/GitLink.java
@@ -13,7 +13,8 @@ package fr.jmini.asciidoctorj.gitlink.internal;
 public class GitLink {
   private String url;
   private String text;
-  private String warning;
+  private String warningLogMessage;
+  private String debugLogMessage;
 
   public String getUrl() {
     return url;
@@ -31,12 +32,20 @@ public class GitLink {
     this.text = text;
   }
 
-  public String getWarning() {
-    return warning;
+  public String getWarningLogMessage() {
+    return warningLogMessage;
   }
 
-  public void setWarning(String warning) {
-    this.warning = warning;
+  public void setWarningLogMessage(String warning) {
+    this.warningLogMessage = warning;
+  }
+
+  public String getDebugLogMessage() {
+    return debugLogMessage;
+  }
+
+  public void setDebugLogMessage(String debugLogMessage) {
+    this.debugLogMessage = debugLogMessage;
   }
 
 }

--- a/src/main/java/fr/jmini/asciidoctorj/gitlink/internal/GitLinkUtility.java
+++ b/src/main/java/fr/jmini/asciidoctorj/gitlink/internal/GitLinkUtility.java
@@ -15,7 +15,8 @@ public final class GitLinkUtility {
   static final String DEFAULT_EDIT_TEXT = "edit on GitHub";
   static final String DEFAULT_VIEW_TEXT = "view on GitHub";
   static final String DEFAULT_BRANCH = "master";
-  static final String WARN_UNEXPECTED_MODE = "git-link: The mode is unexpected, using 'edit' as fallback.";
+  static final String WARN_UNEXPECTED_MODE = "git-link: The mode '%s' is unexpected, using 'view' as fallback.";
+  static final String DEBUG_UNDEFINED_MODE = "git-link: The mode is not defined, using 'view' as fallback.";
   static final String WARN_NO_REPOSITORY_SET = "git-link: There is no repository set.";
   static final String WARN_FILE_UNKNWON = "git-link: path and asciidoctor docfile are unknown";
   static final String WARN_UNEXPECTED_REPOSITORY = "git-link: unexpected repository, should match the GitHub pattern {user}/{git-repository}, current value: ";
@@ -32,16 +33,17 @@ public final class GitLinkUtility {
     }
     if (mode == null) {
       if (modeInput != null && !modeInput.toString().isEmpty()) {
+        String modeInputAsString = modeInput.toString();
         try {
-          mode = GitLinkMode.valueOf(modeInput.toString().toUpperCase());
+          mode = GitLinkMode.valueOf(modeInputAsString.toUpperCase());
         }
         catch (IllegalArgumentException e) {
-          result.setWarning(WARN_UNEXPECTED_MODE);
+          result.setWarningLogMessage(String.format(WARN_UNEXPECTED_MODE, modeInputAsString));
           mode = GitLinkMode.VIEW;
         }
       }
       else {
-        result.setWarning(WARN_UNEXPECTED_MODE);
+        result.setDebugLogMessage(String.format(DEBUG_UNDEFINED_MODE));
         mode = GitLinkMode.VIEW;
       }
     }
@@ -66,10 +68,10 @@ public final class GitLinkUtility {
 
     //Repository:
     if (repository == null || repository.toString().isEmpty()) {
-      result.setWarning(WARN_NO_REPOSITORY_SET);
+      result.setWarningLogMessage(WARN_NO_REPOSITORY_SET);
     }
     else if ((target == null || "self".equals(target)) && (file == null || file.toString().isEmpty())) {
-      result.setWarning(WARN_FILE_UNKNWON);
+      result.setWarningLogMessage(WARN_FILE_UNKNWON);
     }
     else {
       String repoString = (String) repository;
@@ -84,7 +86,7 @@ public final class GitLinkUtility {
         filePath = computeFilePath(file.toString(), repositoryName);
       }
       else {
-        result.setWarning(WARN_UNEXPECTED_REPOSITORY + repoString);
+        result.setWarningLogMessage(WARN_UNEXPECTED_REPOSITORY + repoString);
       }
 
       if (filePath != null) {

--- a/src/test/java/fr/jmini/asciidoctorj/gitlink/GitLinkTest.java
+++ b/src/test/java/fr/jmini/asciidoctorj/gitlink/GitLinkTest.java
@@ -39,8 +39,8 @@ public class GitLinkTest {
     List<LogRecord> logs = runTest("test_empty");
     assertThat(logs).hasSize(1);
     LogRecord log = logs.get(0);
-    assertThat(log.getSeverity()).isEqualTo(Severity.WARN);
-    assertThat(log.getMessage()).isEqualTo("git-link: The mode is unexpected, using 'edit' as fallback.");
+    assertThat(log.getSeverity()).isEqualTo(Severity.DEBUG);
+    assertThat(log.getMessage()).isEqualTo("git-link: The mode is not defined, using 'view' as fallback.");
   }
 
   @Test
@@ -48,8 +48,8 @@ public class GitLinkTest {
     List<LogRecord> logs = runTest("test_empty2");
     assertThat(logs).hasSize(1);
     LogRecord log = logs.get(0);
-    assertThat(log.getSeverity()).isEqualTo(Severity.WARN);
-    assertThat(log.getMessage()).isEqualTo("git-link: The mode is unexpected, using 'edit' as fallback.");
+    assertThat(log.getSeverity()).isEqualTo(Severity.DEBUG);
+    assertThat(log.getMessage()).isEqualTo("git-link: The mode is not defined, using 'view' as fallback.");
   }
 
   @Test
@@ -61,10 +61,13 @@ public class GitLinkTest {
   @Test
   public void testRepositoryMissing() throws Exception {
     List<LogRecord> logs = runTest("test_repository_missing");
-    assertThat(logs).hasSize(1);
-    LogRecord log = logs.get(0);
-    assertThat(log.getSeverity()).isEqualTo(Severity.WARN);
-    assertThat(log.getMessage()).isEqualTo("git-link: There is no repository set.");
+    assertThat(logs).hasSize(2);
+    LogRecord log1 = logs.get(0);
+    assertThat(log1.getSeverity()).isEqualTo(Severity.WARN);
+    assertThat(log1.getMessage()).isEqualTo("git-link: There is no repository set.");
+    LogRecord log2 = logs.get(1);
+    assertThat(log2.getSeverity()).isEqualTo(Severity.DEBUG);
+    assertThat(log2.getMessage()).isEqualTo("git-link: The mode is not defined, using 'view' as fallback.");
   }
 
   @Test

--- a/src/test/java/fr/jmini/asciidoctorj/gitlink/internal/GitLinkUtilityTest.java
+++ b/src/test/java/fr/jmini/asciidoctorj/gitlink/internal/GitLinkUtilityTest.java
@@ -47,162 +47,166 @@ public class GitLinkUtilityTest {
   @Test
   public void testNullRepository() {
     GitLink link = GitLinkUtility.compute(null, "edit", null, null, null, null, FILE);
-    assertLinkEqual(null, DEFAULT_EDIT_LINK_TEXT, GitLinkUtility.WARN_NO_REPOSITORY_SET, link);
+    assertLinkEqual(null, DEFAULT_EDIT_LINK_TEXT, GitLinkUtility.WARN_NO_REPOSITORY_SET, null, link);
   }
 
   @Test
   public void testNullRepositoryWithText() {
     GitLink link = GitLinkUtility.compute(null, "edit", null, null, null, CUSTOM_LINK_TEXT, FILE);
-    assertLinkEqual(null, CUSTOM_LINK_TEXT, GitLinkUtility.WARN_NO_REPOSITORY_SET, link);
+    assertLinkEqual(null, CUSTOM_LINK_TEXT, GitLinkUtility.WARN_NO_REPOSITORY_SET, null, link);
   }
 
   @Test
   public void testEmptyRepository() {
     GitLink link = GitLinkUtility.compute(null, "edit", null, "", null, null, FILE);
-    assertLinkEqual(null, DEFAULT_EDIT_LINK_TEXT, GitLinkUtility.WARN_NO_REPOSITORY_SET, link);
+    assertLinkEqual(null, DEFAULT_EDIT_LINK_TEXT, GitLinkUtility.WARN_NO_REPOSITORY_SET, null, link);
   }
 
   @Test
   public void testFileUnknownFileAndPath() {
     GitLink link = GitLinkUtility.compute(null, "edit", null, REPO, null, null, null);
-    assertLinkEqual(null, DEFAULT_EDIT_LINK_TEXT, GitLinkUtility.WARN_FILE_UNKNWON, link);
+    assertLinkEqual(null, DEFAULT_EDIT_LINK_TEXT, GitLinkUtility.WARN_FILE_UNKNWON, null, link);
   }
 
   @Test
   public void testWrongRepository() {
     GitLink link = GitLinkUtility.compute(null, "edit", null, "xxx", null, null, FILE);
-    assertLinkEqual(null, DEFAULT_EDIT_LINK_TEXT, GitLinkUtility.WARN_UNEXPECTED_REPOSITORY + "xxx", link);
+    assertLinkEqual(null, DEFAULT_EDIT_LINK_TEXT, GitLinkUtility.WARN_UNEXPECTED_REPOSITORY + "xxx", null, link);
   }
 
   @Test
   public void testWrongRepository2() {
     GitLink link = GitLinkUtility.compute(null, "edit", null, "zzz/", null, null, FILE);
-    assertLinkEqual(null, DEFAULT_EDIT_LINK_TEXT, GitLinkUtility.WARN_UNEXPECTED_REPOSITORY + "zzz/", link);
+    assertLinkEqual(null, DEFAULT_EDIT_LINK_TEXT, GitLinkUtility.WARN_UNEXPECTED_REPOSITORY + "zzz/", null, link);
   }
 
   @Test
   public void testOkDefaultEdit() {
     GitLink link = GitLinkUtility.compute(null, "edit", null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/my_file.txt", DEFAULT_EDIT_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/my_file.txt", DEFAULT_EDIT_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkDefaultView() {
     GitLink link = GitLinkUtility.compute(null, "view", null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/blob/master/my_file.txt", DEFAULT_VIEW_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/blob/master/my_file.txt", DEFAULT_VIEW_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testNullMode() {
     GitLink link = GitLinkUtility.compute(null, null, null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/blob/master/my_file.txt", DEFAULT_VIEW_LINK_TEXT, GitLinkUtility.WARN_UNEXPECTED_MODE, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/blob/master/my_file.txt", DEFAULT_VIEW_LINK_TEXT, null, GitLinkUtility.DEBUG_UNDEFINED_MODE, link);
   }
 
   @Test
   public void testWrongMode() {
     GitLink link = GitLinkUtility.compute(null, "xxx", null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/blob/master/my_file.txt", DEFAULT_VIEW_LINK_TEXT, GitLinkUtility.WARN_UNEXPECTED_MODE, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/blob/master/my_file.txt", DEFAULT_VIEW_LINK_TEXT, "git-link: The mode 'xxx' is unexpected, using 'view' as fallback.", null, link);
+
+    GitLink link2 = GitLinkUtility.compute(null, "abc", null, REPO, null, null, FILE);
+    assertLinkEqual("https://github.com/jmini/some-repo/blob/master/my_file.txt", DEFAULT_VIEW_LINK_TEXT, "git-link: The mode 'abc' is unexpected, using 'view' as fallback.", null, link2);
   }
 
   @Test
   public void testOkWithPath1() {
     GitLink link = GitLinkUtility.compute("path/to/this/File.adoc", "edit", null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/path/to/this/File.adoc", DEFAULT_EDIT_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/path/to/this/File.adoc", DEFAULT_EDIT_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkWithPath2() {
     GitLink link = GitLinkUtility.compute("/path/to/this/File.txt", "edit", null, REPO, null, null, SUB_FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/path/to/this/File.txt", DEFAULT_EDIT_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/path/to/this/File.txt", DEFAULT_EDIT_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkWithPathUnknownFile() {
     GitLink link = GitLinkUtility.compute("/path/to/this/File.txt", "edit", null, REPO, null, null, null);
-    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/path/to/this/File.txt", DEFAULT_EDIT_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/path/to/this/File.txt", DEFAULT_EDIT_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkDefaultForSubFile() {
     GitLink link = GitLinkUtility.compute(null, "edit", null, REPO, null, null, SUB_FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/folder/TEXT.adoc", DEFAULT_EDIT_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/folder/TEXT.adoc", DEFAULT_EDIT_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkCustomBranch() {
     GitLink link = GitLinkUtility.compute(null, "edit", null, REPO, "features/preview", null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/edit/features/preview/my_file.txt", DEFAULT_EDIT_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/edit/features/preview/my_file.txt", DEFAULT_EDIT_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkCustomText() {
     GitLink link = GitLinkUtility.compute(null, "edit", null, REPO, null, CUSTOM_LINK_TEXT, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/my_file.txt", CUSTOM_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/edit/master/my_file.txt", CUSTOM_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkViewDir() {
     GitLink link = GitLinkUtility.compute("some/folder", "viewdir", null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/tree/master/some/folder", DEFAULT_VIEW_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/tree/master/some/folder", DEFAULT_VIEW_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkViewDirTrailingSlash() {
     GitLink link = GitLinkUtility.compute("some/folder/", "viewdir", null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/tree/master/some/folder", DEFAULT_VIEW_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/tree/master/some/folder", DEFAULT_VIEW_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkViewDirStartWithDot() {
     GitLink link = GitLinkUtility.compute("./some/folder", "viewdir", null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/tree/master/some/folder", DEFAULT_VIEW_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/tree/master/some/folder", DEFAULT_VIEW_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkViewDirDotSlash() {
     GitLink link = GitLinkUtility.compute("./", "viewdir", null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/tree/master", DEFAULT_VIEW_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/tree/master", DEFAULT_VIEW_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkViewDirDotSlashOtherBranch() {
     GitLink link = GitLinkUtility.compute("./", "viewdir", null, REPO, "gh-pages", null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/tree/gh-pages", DEFAULT_VIEW_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/tree/gh-pages", DEFAULT_VIEW_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testEditButShouldBeViewDir() {
     GitLink link = GitLinkUtility.compute("some/folder/", "edit", null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/tree/master/some/folder", DEFAULT_VIEW_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/tree/master/some/folder", DEFAULT_VIEW_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testViewButShouldBeViewDir() {
     GitLink link = GitLinkUtility.compute("some/folder/", "view", null, REPO, null, null, FILE);
-    assertLinkEqual("https://github.com/jmini/some-repo/tree/master/some/folder", DEFAULT_VIEW_LINK_TEXT, null, link);
+    assertLinkEqual("https://github.com/jmini/some-repo/tree/master/some/folder", DEFAULT_VIEW_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkOtherServer() {
     GitLink link = GitLinkUtility.compute(null, "edit", "https://git.server.com", REPO, null, null, FILE);
-    assertLinkEqual("https://git.server.com/jmini/some-repo/edit/master/my_file.txt", DEFAULT_EDIT_LINK_TEXT, null, link);
+    assertLinkEqual("https://git.server.com/jmini/some-repo/edit/master/my_file.txt", DEFAULT_EDIT_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkOtherServerTrailingSlash() {
     GitLink link = GitLinkUtility.compute(null, "edit", "https://git.server.com/", REPO, null, null, FILE);
-    assertLinkEqual("https://git.server.com/jmini/some-repo/edit/master/my_file.txt", DEFAULT_EDIT_LINK_TEXT, null, link);
+    assertLinkEqual("https://git.server.com/jmini/some-repo/edit/master/my_file.txt", DEFAULT_EDIT_LINK_TEXT, null, null, link);
   }
 
   @Test
   public void testOkOtherServerOtherBranch() {
     GitLink link = GitLinkUtility.compute(null, "view", "https://server.com/git-manager", REPO, "features/test", null, FILE);
-    assertLinkEqual("https://server.com/git-manager/jmini/some-repo/blob/features/test/my_file.txt", DEFAULT_VIEW_LINK_TEXT, null, link);
+    assertLinkEqual("https://server.com/git-manager/jmini/some-repo/blob/features/test/my_file.txt", DEFAULT_VIEW_LINK_TEXT, null, null, link);
   }
 
-  private static void assertLinkEqual(String url, String text, String warning, GitLink actual) {
+  private static void assertLinkEqual(String url, String text, String warning, String debug, GitLink actual) {
     assertThat(actual.getUrl()).describedAs("url").isEqualTo(url);
     assertThat(actual.getText()).describedAs("text").isEqualTo(text);
-    assertThat(actual.getWarning()).describedAs("warning").isEqualTo(warning);
+    assertThat(actual.getWarningLogMessage()).describedAs("warning").isEqualTo(warning);
+    assertThat(actual.getDebugLogMessage()).describedAs("debug").isEqualTo(debug);
   }
 }


### PR DESCRIPTION
* `view` is the fallback (log entry was mentioning `edit`)
* Log level when undefined is `DEBUG`, message is adjusted.
* The unexpected value is added to the existing `WARN` log message.